### PR TITLE
Bump spark-core_2.12 from 3.0.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <properties>
         <scala.version>2.12.12</scala.version>
-        <spark.version>3.0.0</spark.version>
+        <spark.version>3.4.0</spark.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Bumps spark-core_2.12 from 3.0.0 to 3.4.0.

---
updated-dependencies:
- dependency-name: org.apache.spark:spark-core_2.12 dependency-type: direct:production ...